### PR TITLE
Luxembourg TRP-VC Streets Dataset

### DIFF
--- a/data/luxembourg/README.md
+++ b/data/luxembourg/README.md
@@ -2,6 +2,36 @@
 
 Source: <https://data.public.lu/fr/datasets/transport-et-voies-de-communication/>
 
+Complete description of all attributes: <https://data.public.lu/fr/datasets/r/d2d92fc6-1cfa-4c97-8e41-31e78f443099>
+
 ## Filters
 
+```sql
+"NOM_RUE" <> '' AND ("TRP_CLAS_L" <> 'Chemin de fer' OR ("TRP_CLAS_L" <> 'Non codé' AND "TRP_CLAS_L" <> 'autre'))
+```
+
+Filtering out features without a name, and features which aren't streets (train tracks, forest tracks, and unknown classification).
+
+| Value | Description (original) | Description (translated) |
+|-------|------------------------|--------------------------|
+| NOM_RUE | Nom de la rue  | Street name |
+| TRP_CLAS_L | Classification | Street Classification |
+
 ## Tags
+The tagging scheme follows the [convention used in Luxembourg](https://wiki.openstreetmap.org/wiki/WikiProject_Luxembourg/Roads#Overview).
+
+### `TRP_CLAS_L` (*TRP_CLASS_LOOKUP*)
+| Value | Description | OSM Tags |
+|-------|-------------|----------|
+| Autoroute | Highway | `highway=motorway` |
+| Nationale | National road | `highway=primary` |
+| Chemin repris | State-managed road | `highway=secondary` |
+| Chemin vicinal | Residential road | `highway=residential` |
+| Chemin de fer | Train tracks | |
+| Non codé | Tracks | |
+| autre | Other | |
+
+### `TRP_NIVE_L` (*TRP_NIVEAU_LOOKUP*)
+| Value | Description | OSM Tags |
+|-------|-------------|----------|
+|passage supérieur 1|Bridge|`bridge=yes` and `layer=1`|

--- a/data/luxembourg/README.md
+++ b/data/luxembourg/README.md
@@ -1,0 +1,7 @@
+# Road Completion - 🇱🇺 Luxembourg
+
+Source: <https://data.public.lu/fr/datasets/transport-et-voies-de-communication/>
+
+## Filters
+
+## Tags

--- a/data/luxembourg/build-extended-conversion.js
+++ b/data/luxembourg/build-extended-conversion.js
@@ -1,0 +1,39 @@
+'use strict'
+
+const fs = require('fs');
+
+var args = process.argv.slice(2);
+const sourceA = args[0];
+const sourceB = args[1];
+const append = args[2];
+const target = args[3];
+
+function convert_csv_tuples_to_json(filePath) {
+    const data = fs.readFileSync(filePath, 'utf8');
+    let inputRows = data.split(/\r?\n/);
+    
+    let result = {}
+    
+    inputRows.forEach(element => {
+        if(element.charAt(0) === "#") {
+            return;
+        }
+        var [id, name] = element.split(/\t/);
+        result[id] = {"name": name};
+    });
+
+    return result;
+}
+
+let normalizeNames = { 
+    NOM_RUE: convert_csv_tuples_to_json(sourceA),
+    ID_RUE_CAC: convert_csv_tuples_to_json(sourceB)
+};
+
+const convertTags = JSON.parse(fs.readFileSync(append, 'utf8'));
+let data = JSON.stringify({
+    ...convertTags,
+    ...normalizeNames
+});
+
+fs.writeFileSync(target, data);

--- a/data/luxembourg/convert.json
+++ b/data/luxembourg/convert.json
@@ -1,0 +1,19 @@
+{
+  "TRP_CLAS_L": {
+    "Nationale": {
+      "highway": "primary"
+    },
+    "Chemin repris": {
+      "highway": "secondary"
+    },
+    "Autoroute": {
+      "highway": "motorway"
+    }
+  },
+  "TRP_NIVE_L": {
+    "passage supérieur 1": {
+      "bridge": "yes",
+      "layer": "1"
+    }
+  }
+}

--- a/data/luxembourg/convert.json
+++ b/data/luxembourg/convert.json
@@ -1,13 +1,16 @@
 {
   "TRP_CLAS_L": {
+    "Autoroute": {
+      "highway": "motorway"
+    },
     "Nationale": {
       "highway": "primary"
     },
     "Chemin repris": {
       "highway": "secondary"
     },
-    "Autoroute": {
-      "highway": "motorway"
+    "Chemin vicinal": {
+      "highway": "residential"
     }
   },
   "TRP_NIVE_L": {

--- a/data/luxembourg/create-uid.js
+++ b/data/luxembourg/create-uid.js
@@ -1,0 +1,26 @@
+'use strict'
+
+const fs = require('fs');
+const crypto = require('crypto');
+
+var args = process.argv.slice(2);
+const source = args[0];
+const target = args[1];
+
+const data = JSON.parse(fs.readFileSync(source, 'utf8'));
+
+data['features'].forEach(element => {
+    let uid = hashProperties(element['geometry']);
+    element['properties']['original:uid'] = uid;
+});
+
+function hashProperties(properties) {
+    let mergedCoordinates = "";
+    properties.coordinates.forEach(element => {
+      mergedCoordinates += element[0] + element[1];
+    });
+    let hash = crypto.createHash('md5').update(mergedCoordinates).digest('hex');
+    return hash;
+}
+
+fs.writeFileSync(target, JSON.stringify(data));

--- a/data/luxembourg/filter.sql
+++ b/data/luxembourg/filter.sql
@@ -1,0 +1,2 @@
+SELECT * FROM "TRP_VC" WHERE
+  "NOM_RUE" <> '' AND ("TRP_CLAS_L" <> 'Chemin de fer' OR ("TRP_CLAS_L" <> 'Non codé' AND "TRP_CLAS_L" <> 'autre'))

--- a/data/luxembourg/luxembourg.sh
+++ b/data/luxembourg/luxembourg.sh
@@ -1,0 +1,37 @@
+#!/bin/sh
+
+# Make script directory working directory
+
+cd `dirname "$(realpath $0)"`
+
+# Download Luxembourg extract
+
+if [ -f "luxembourg-latest.osm.pbf" ]; then rm "luxembourg-latest.osm.pbf"; fi
+
+wget https://download.geofabrik.de/europe/luxembourg-latest.osm.pbf
+
+# Convert to GeoJSON
+
+if [ -f "./luxembourg-lines.geojson" ]; then rm "./luxembourg-lines.geojson"; fi
+if [ -f "./luxembourg-polygons.geojson" ]; then rm "./luxembourg-polygons.geojson"; fi
+
+ogr2ogr -f "GeoJSON" -progress \
+  -sql "SELECT name, highway FROM lines WHERE highway IS NOT NULL" \
+  "./luxembourg-lines.geojson" \
+  "./luxembourg-latest.osm.pbf"
+ogr2ogr -f "GeoJSON" -progress \
+  -sql "SELECT name, hstore_get_value(other_tags, 'highway') AS highway, place FROM multipolygons WHERE (hstore_get_value(other_tags, 'highway') is not null) OR (place = 'square')" \
+  "./luxembourg-polygons.geojson" \
+  "./luxembourg-latest.osm.pbf"
+
+# Generate buffer
+
+node "../../script/buffer.js" --radius=20 "./luxembourg-lines.geojson" "luxembourg-lines-buffers.geojson"
+node "../../script/buffer.js" --radius=5 "./luxembourg-polygons.geojson" "luxembourg-polygons-buffers.geojson"
+
+# Generate vector tiles
+
+tippecanoe --force --no-feature-limit --no-tile-size-limit \
+  --maximum-zoom=14 --minimum-zoom=14 \
+  --layer="buffers" \
+  --output="./luxembourg-buffers.mbtiles" "./luxembourg-lines-buffers.geojson" "./luxembourg-polygons-buffers.geojson"

--- a/data/luxembourg/process.sh
+++ b/data/luxembourg/process.sh
@@ -1,0 +1,80 @@
+#!/bin/sh
+
+FILENAME="transport-et-voies-de-communication-shape"
+MAPROULETTE_CHALLENGE=17749
+
+# Make script directory working directory
+
+cd `dirname "$(realpath $0)"`
+
+# Download & unzip data
+
+mkdir -p "./source/"
+
+if [ ! -d "./source/$FILENAME" ]; then
+  wget -O "./source/$FILENAME.zip" "https://data.public.lu/fr/datasets/r/e74aadad-77c2-441e-98fe-e08a441484a2"
+  unzip -j "./source/$FILENAME.zip" -d "./source/$FILENAME/" "TRP_VC.*"
+fi
+
+# Convert to GeoJSON
+
+if [ -d "./temp" ]; then rm -r "./temp/"; fi
+
+mkdir -p "./temp/"
+
+ogr2ogr -f "GeoJSON" -progress \
+  --config SHAPE_ENCODING "ISO-8859-1" \
+  -s_srs "EPSG:2169" -t_srs "EPSG:4326" \
+  -sql "@filter.sql" \
+  -lco COORDINATE_PRECISION=6 \
+  -fieldTypeToString "All" \
+  "./temp/trpvc.geojson" \
+  "./source/$FILENAME/TRP_VC.shp"
+
+
+# Before conferting the fields into OpenStreetMap tags, we extend convert.json with our street name standardization
+# Download our community-driven street name standardization tuples
+
+wget -O "./temp/csventrifuge_enhance_name.csv" "https://raw.githubusercontent.com/osmlu/csventrifuge/master/rules/luxembourg_addresses/rue.csv"
+wget -O "./temp/csventrifuge_enhance_id.csv" "https://raw.githubusercontent.com/osmlu/csventrifuge/master/enhance/luxembourg_addresses/id_caclr_rue/rue.csv"
+
+#  Convert the tuples into JSON and merge them with convert.json
+
+node "./build-extended-conversion.js" "./temp/csventrifuge_enhance_name.csv" "./temp/csventrifuge_enhance_id.csv" "convert.json" "./temp/convert-merged.json"
+
+# Finally, convert fields to OpenStreetMap tags
+
+node "../../script/convert-tags.js" -c "./temp/convert-merged.json" "./temp/trpvc.geojson" "trpvcTagged.geojson"
+
+# Generate vector tiles
+
+tippecanoe --force --no-feature-limit --no-tile-size-limit \
+  --buffer=0 \
+  --maximum-zoom=14 --minimum-zoom=14 \
+  --layer="roads" \
+  --output="./temp/trpvcTagged.mbtiles" "./temp/trpvcTagged.geojson"
+
+# Generate MapRoulette NotAnIssue buffers vector tiles
+
+wget -O "./temp/maproulette.geojson" "https://maproulette.org/api/v2/challenge/view/$MAPROULETTE_CHALLENGE?status=2"
+
+node "../../script/buffer.js" --radius=20 "./temp/maproulette.geojson" "maproulette-buffers.geojson"
+
+# Merge MapRoulette buffers to OpenStreetMap buffers
+
+tippecanoe --force --no-feature-limit --no-tile-size-limit \
+  --maximum-zoom=14 --minimum-zoom=14 \
+  --layer="buffers" \
+  --output="./temp/luxembourg-buffers.mbtiles" \
+  "./luxembourg-lines-buffers.geojson" "./luxembourg-polygons-buffers.geojson" "./temp/maproulette-buffers.geojson"
+
+# Difference
+
+if [ -d "./difference" ]; then rm -r "./difference/"; fi
+
+mkdir -p "./difference"
+
+node "../../script/difference.js" --output-dir="./difference" "./temp/trpvcTagged.mbtiles" "./temp/luxembourg-buffers.mbtiles"
+
+# Our dataset doesn't have unique identifiers for segments of the same road, so we create one based on the geometry
+node "./create-uid.js" "./difference/diff.geojson" "./difference/diff.geojson"


### PR DESCRIPTION
Hello everyone, 
I finally got around to implementing the TRP-VC dataset integration for Luxembourg (#3).
There was some data wrangling required, which was solved with two scripts:

### build-extended-conversion.js
In Luxembourg, we normalize our street names using @grischard's [csventrifuge](https://github.com/osmlu/csventrifuge). This script grabs the CSV files that contain the rewrite rules, converts them into JSON and creates a custom convert.json which rewrites street names based on it's name, or on its street identifier. Then, we merge the versioned convert.json and execute convert-tags once.

Ideally, I would've executed convert-tags.js twice, first using the versioned convert.json, and a second time using the street name normalization convert.json. However, [convert-tags](https://github.com/osmbe/road-completion/blob/a9b0c539d84900b421e09f0f301846b2f95ebc5d/script/src/convert-tags.ts#L40) appends "original:" to all properties, so I ended up with "original:original:ATTR". We execute this late in the processing pipeline, as re-tagging the whole dataset beforehand is wasteful (unless #7 is implemented, then we need to retag the dataset beforehand).

### create-uid.js
Our dataset doesn't have unique identifiers, as multiple segments of the same street have the identical ID_CAC_RUE. Therefore, we create a (quick and dirty) hash of the geometry, which we use as an identifier for MapRoulette. The assumption is that if the geometry changes, the changes will pop up again for review.

Is this something you would be interested in merging into your project? If you prefer the scripts be rewritten into TypeScript and included into your scripts folder, let me know (I don't mind the effort). We (@grischard and I) have been using the resulting diff.geojson to map new streets already. @grischard, are there improvements we could make to the processing pipeline?

I created a [MapRoulette challenge](https://maproulette.org/browse/challenges/17749) to close the processing pipeline loop.

Update: I've gone through a couple of tasks and found most of them to be useful.

1. Sometimes OSM has a turning_circle at the end of a residential highway and TRP-VC has the way going on for a couple of additional meters. This could probably be resolved with a larger buffer, but its not big deal.
2. TRP-VC often adds the name of the "main" street to private driveways. I updated the MapRoulette instructions to describe what to do.
